### PR TITLE
fix baseurl usage, link would bring user to current page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
 
         <div class="wrap_header">
             <!-- logo -->
-            <a href="{{ site.base_url }}" class="logo">
+            <a href="{{ site.baseurl }}" class="logo">
                 ICSS
             </a>
             <!-- nav -->


### PR DESCRIPTION
wrong variable name meant link was "" instead of the homepage, use `site.baseurl` instead